### PR TITLE
Explicitely use display:inline-block instead of jQuery show() function

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -28,9 +28,9 @@ module.exports =
     extensions = (atom.config.get('wordcount.extensions') || []).map (extension) -> extension.toLowerCase()
     current_file_extension = item?.buffer?.file?.path.split('.').pop().toLowerCase()
     if current_file_extension in extensions
-      view.show()
+      view.css("display", "inline-block")
     else
-      view.hide()
+      view.css("display", "none")
 
   consumeStatusBar: (statusBar) ->
     tile = statusBar.addRightTile(item: view, priority: 100)


### PR DESCRIPTION
Use display:inline-block instead of jQuery's show() function (which is using display:block).

Fixes a bug in which the word count div was pushing the other divs (like the encoding and grammar selectors) outside of the bar