### PR TITLE
Optionally do not count words in code blocks

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -38,6 +38,14 @@ module.exports =
       type: 'string'
       default: '20%'
       order: 5
+    ignorecode:
+      title: 'Ignore markdown code blocks'
+      description: 'do not count words inside of code blocks'
+      type: 'boolean'
+      default: false
+      items:
+        type: 'boolean'
+      order: 6
 
   activate: (state) ->
     view = new WordcountView()

--- a/lib/wordcount-view.coffee
+++ b/lib/wordcount-view.coffee
@@ -40,6 +40,10 @@ class WordcountView extends View
     selection || text
 
   count: (text) ->
+    if atom.config.get('wordcount.ignorecode')
+      codePatterns = [/`{3}(.|\s)*?`{3}/g, /[ ]{4}.*?$/gm]
+      for pattern in codePatterns
+        text = text?.replace pattern, ''
     words = text?.match(/\S+/g)?.length
     chars = text?.length
     [words, chars]


### PR DESCRIPTION
This PR addresses issue #41 and adds an option to the plugin settings to not count words in both

- Markdown (indented by 4 spaces)
- Github-flavored markdown (enclosed in three backticks ```)

code blocks.