### PR TITLE
Make plugin work in unsaved buffers

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -57,9 +57,10 @@ module.exports =
 
   show_or_hide_for_item: (item) ->
     extensions = (atom.config.get('wordcount.extensions') || []).map (extension) -> extension.toLowerCase()
+    not_saved = not item?.buffer?.file?
     no_extension = atom.config.get('wordcount.noextension') && item?.buffer?.file?.path.split('.').length == 1
     current_file_extension = item?.buffer?.file?.path.split('.').pop().toLowerCase()
-    if no_extension or current_file_extension in extensions
+    if no_extension or current_file_extension in extensions or not_saved
       view.css("display", "inline-block")
     else
       view.css("display", "none")


### PR DESCRIPTION
I added a `not_saved` guard to make the plugin work in unsaved buffers, as requested in issue #42.