### PR TITLE
Add "Always On" setting

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -7,47 +7,53 @@ tile = null
 module.exports =
 
   config:
+    alwaysOn:
+      title: 'Always on'
+      description: 'Show word count for all files, regardless of extension'
+      type: 'boolean'
+      default: false
+      order: 1
     extensions:
       title: 'Autoactivated file extensions'
-      description: 'list of file extenstions which should have the wordcount plugin enabled'
+      description: 'List of file extenstions which should have the wordcount plugin enabled'
       type: 'array'
       default: [ 'md', 'markdown', 'readme', 'txt', 'rst', 'adoc', 'log', 'msg' ]
       items:
         type: 'string'
-      order: 1
+      order: 2
     noextension:
       title: 'Autoactivate for files without an extension'
-      description: 'wordcount plugin enabled for files without a file extension'
+      description: 'Wordcount plugin enabled for files without a file extension'
       type: 'boolean'
       default: false
       items:
         type: 'boolean'
-      order: 2
+      order: 3
     goal:
       title: 'Work toward a word goal'
-      description: 'shows a bar showing progress toward a word goal'
+      description: 'Shows a bar showing progress toward a word goal'
       type: 'number'
       default: 0
-      order: 3
+      order: 4
     goalColor:
       title: 'Color for word goal'
-      description: 'use a CSS color value, such as rgb(0, 85, 255) or green'
+      description: 'Use a CSS color value, such as rgb(0, 85, 255) or green'
       type: 'string'
       default: 'rgb(0, 85, 0)'
-      order: 4
+      order: 5
     goalLineHeight:
       title: 'Percentage height of word goal line'
       type: 'string'
       default: '20%'
-      order: 5
+      order: 6
     ignorecode:
       title: 'Ignore Markdown code blocks'
-      description: 'do not count words inside of code blocks'
+      description: 'Do not count words inside of code blocks'
       type: 'boolean'
       default: false
       items:
         type: 'boolean'
-      order: 6
+      order: 7
 
   activate: (state) ->
     view = new WordcountView()
@@ -69,11 +75,12 @@ module.exports =
       view.css('background', 'transparent')
 
   show_or_hide_for_item: (item) ->
+    alwaysOn = atom.config.get('wordcount.alwaysOn')
     extensions = (atom.config.get('wordcount.extensions') || []).map (extension) -> extension.toLowerCase()
     not_saved = not item?.buffer?.file?
     no_extension = atom.config.get('wordcount.noextension') && item?.buffer?.file?.path.split('.').length == 1
     current_file_extension = item?.buffer?.file?.path.split('.').pop().toLowerCase()
-    if no_extension or current_file_extension in extensions or not_saved
+    if alwaysOn or no_extension or current_file_extension in extensions or not_saved
       view.css("display", "inline-block")
     else
       view.css("display", "none")


### PR DESCRIPTION
Adds a setting called "Always On" that causes the package to ignore the "Autoactivated file extensions" setting and turn on the word count for all files.

Also capitalizes the description attribute of other settings, in line with the convention of other packages.

Fixes #35.

(I had to close #56 because of branching problems.)