### PR TITLE
Added the ability to count the total price for the text file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Counts the words and characters in your current document and displays them in th
   - Writing goal tracker (with custom colors support)
   - Works with unsaved files
   - Option to exclude `codeblocks` from count
+  - Option to show the total price per word for the document. Currency symbol can be changed in Settings.
 
 
 ![A screenshot of your spankin' package](https://cloud.githubusercontent.com/assets/584259/19187373/62f97ad8-8c8b-11e6-85aa-1282f94f509b.gif))

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -78,7 +78,7 @@ module.exports =
 
   update_goal: (item) ->
     if item is 0
-      view.css('background', 'transparent')
+      view.element.style.background = 'transparent'
 
   show_or_hide_for_item: (item) ->
     {alwaysOn, extensions, noextension} = atom.config.get('wordcount')
@@ -93,12 +93,12 @@ module.exports =
       no_extension = true
 
     if alwaysOn or no_extension or current_file_extension in extensions
-      view.css("display", "inline-block") unless not_text_editor
+      view.element.style.display = "inline-block" unless not_text_editor
     else
-      view.css("display", "none")
+      view.element.style.display = "none"
 
   consumeStatusBar: (statusBar) ->
-    tile = statusBar.addRightTile(item: view, priority: 100)
+    tile = statusBar.addRightTile(item: view.element, priority: 100)
 
   deactivate: ->
     tile?.destroy()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -60,6 +60,24 @@ module.exports =
       type: 'boolean'
       default: false
       order: 8
+    showprice:
+      title: 'Do you get paid per word?'
+      description: 'Shows the price for the text per word'
+      type: 'boolean'
+      default: false
+      order: 9
+    wordprice:
+      title: 'How much do you get paid per word?'
+      description: 'Allows you to find out how much do you get paid per word'
+      type: 'string'
+      default: '0.15'
+      order: 10
+    currencysymbol:
+      title: 'Set a different currency symbol'
+      description: 'Allows you to change the currency you get paid with'
+      type: 'string'
+      default: '₴'
+      order: 11
 
   activate: (state) ->
     view = new WordcountView()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -89,8 +89,7 @@ module.exports =
     untitled_tab = buffer?.file is null
     current_file_extension = buffer?.file?.path.match(/\.(\w+)$/)?[1].toLowerCase()
 
-    if noextension and (not current_file_extension? or untitled_tab)
-      no_extension = true
+    no_extension = noextension and (not current_file_extension? or untitled_tab)
 
     if alwaysOn or no_extension or current_file_extension in extensions
       view.element.style.display = "inline-block" unless not_text_editor

--- a/lib/wordcount-view.coffee
+++ b/lib/wordcount-view.coffee
@@ -1,16 +1,17 @@
-{View} = require 'atom-space-pen-views'
 
 module.exports =
-class WordcountView extends View
+class WordcountView
   CSS_SELECTED_CLASS: 'wordcount-select'
 
   constructor: ->
-    super
-    @divWords = document.createElement 'div'
-    @append @divWords
+    @element = document.createElement 'div'
+    @element.classList.add('word-count')
+    @element.classList.add('inline-block')
 
-  @content: ->
-    @div class: 'word-count inline-block'
+    @divWords = document.createElement 'div'
+
+    @element.appendChild(@divWords)
+
 
   update_count: (editor) ->
     text = @getCurrentText editor
@@ -21,22 +22,22 @@ class WordcountView extends View
       if not @divGoal
         @divGoal = document.createElement 'div'
         @divGoal.style.width = '100%'
-        @append @divGoal
+        @element.appendChild @divGoal
       green = Math.round(wordCount / goal * 100)
       green = 100 if green > 100
       color = atom.config.get 'wordcount.goalColor'
       @divGoal.style.background = '-webkit-linear-gradient(left, ' + color + ' ' + green + '%, transparent 0%)'
       percent = parseFloat(atom.config.get 'wordcount.goalLineHeight') / 100
-      height = @height() * percent;
+      height = @element.style.height * percent
       @divGoal.style.height = height + 'px'
       @divGoal.style.marginTop = -height + 'px'
 
   getCurrentText: (editor) =>
     selection = editor.getSelectedText()
     if selection
-      @addClass @CSS_SELECTED_CLASS
+      @element.classList.add @CSS_SELECTED_CLASS
     else
-      @removeClass @CSS_SELECTED_CLASS
+      @element.classList.remove @CSS_SELECTED_CLASS
     text = editor.getText()
     selection || text
 

--- a/lib/wordcount-view.coffee
+++ b/lib/wordcount-view.coffee
@@ -18,6 +18,8 @@ class WordcountView
     [wordCount, charCount] = @count text
     @divWords.innerHTML = "#{wordCount || 0} W"
     @divWords.innerHTML += (" | #{charCount || 0} C") unless atom.config.get('wordcount.hidechars')
+    priceResult = wordCount*atom.config.get('wordcount.wordprice')
+    @divWords.innerHTML += (" | #{priceResult.toFixed(2) || 0} ")+atom.config.get('wordcount.currencysymbol') if atom.config.get('wordcount.showprice')
     if goal = atom.config.get 'wordcount.goal'
       if not @divGoal
         @divGoal = document.createElement 'div'

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "atom": ">=0.180.0"
   },
   "dependencies": {
-    "atom-space-pen-views": "^2.0.3",
     "lodash": "^3.10.1"
   },
   "consumedServices": {

--- a/spec/test.md
+++ b/spec/test.md
@@ -1,0 +1,1 @@
+This is some test document.

--- a/spec/wordcount-spec.coffee
+++ b/spec/wordcount-spec.coffee
@@ -1,4 +1,4 @@
-wordcount = require '../lib/wordcount'
+wordcount = require '../lib/main'
 
 # Use the command `window:run-package-specs` (cmd-alt-ctrl-p) to run specs.
 #


### PR DESCRIPTION
For cases when a person (like me :) ) gets paid per word.
It is possible to toggle the price counting in the settings, to set the price per word, and change the default currency symbol.
Just a minor, but useful addition, I think)

Thanks for the plugin!